### PR TITLE
feat: add click-to-show option for filtered comments

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -153,6 +153,18 @@
               Show detailed logs in browser console
             </p>
           </div>
+
+          <div class="setting-group">
+            <label class="toggle-label">
+              <input type="checkbox" id="clickToShow" />
+              <span class="toggle-slider"></span>
+              Click to Show Filtered Comments
+            </label>
+            <p class="setting-description">
+              When enabled, filtered comments require a click to show instead of
+              hover
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -9,6 +9,7 @@ const DEFAULT_SETTINGS = {
   hideDefaultAvatars: true,
   debug: false,
   grayscaleOpacity: 0.3,
+  clickToShow: false,
 };
 
 class PopupController {
@@ -151,6 +152,12 @@ class PopupController {
       this.saveSettings();
     });
 
+    // Click to show toggle
+    document.getElementById("clickToShow").addEventListener("change", (e) => {
+      this.settings.clickToShow = e.target.checked;
+      this.saveSettings();
+    });
+
     // Grayscale opacity slider
     const opacitySlider = document.getElementById("grayscaleOpacity");
     const opacityValue = document.getElementById("opacityValue");
@@ -238,6 +245,9 @@ class PopupController {
 
     // Update debug mode
     document.getElementById("debugMode").checked = this.settings.debug;
+
+    // Update click to show setting
+    document.getElementById("clickToShow").checked = this.settings.clickToShow;
 
     // Update grayscale opacity slider
     const opacitySlider = document.getElementById("grayscaleOpacity");

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,7 +7,24 @@
   transition: all 0.3s ease;
 }
 
+/* Hover mode (default) */
 .threads-filter-grayscale:hover {
+  filter: grayscale(50%);
+  opacity: 0.8;
+}
+
+/* Click mode - disable hover effects */
+.threads-filter-grayscale.click-mode {
+  cursor: pointer;
+}
+
+.threads-filter-grayscale.click-mode:hover {
+  filter: grayscale(100%);
+  opacity: var(--threads-filter-opacity, 0.3);
+}
+
+/* Click mode - when clicked/toggled */
+.threads-filter-grayscale.click-mode.showing {
   filter: grayscale(50%);
   opacity: 0.8;
 }


### PR DESCRIPTION
- Add new setting 'Click to Show Filtered Comments' in Advanced Settings
- When enabled, filtered comments require click to reveal instead of hover
- Add click-mode CSS classes and event handlers
- Implement toggle functionality for showing/hiding filtered comments
- Update existing comments when setting changes
- Maintain backward compatibility with hover mode